### PR TITLE
Use global currentRetryCount; Use default roles if no roles are provided

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@ npm-debug.log
 Thumbs.db
 .DS_Store
 # Ignored files
-*.ts
 !*.d.ts
 .idea/
 .dist/

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,0 @@
-import {Promise} from 'es6-shim';
-
-export {WebWorkerTransport} from './src/Transport/WebWorkerTransport';
-export {WebSocketTransport} from './src/Transport/WebSocketTransport';
-export {Client} from './src/Client';
-export {retryWhen} from './src/Client';
-export * from './src/Client';

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -151,6 +151,7 @@ export class Client {
                 .do((msg: IMessage) => {
                     if (msg instanceof OpenMessage) {
                         currentRetryCount = 0;
+                        o.roles = o.roles || Client.roles();
                         const helloMsg = new HelloMessage(r, o);
                         transport.next(helloMsg);
                     }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -61,7 +61,6 @@ export class Client {
     private _session: Observable<SessionData>;
     private _transport: Subject<IMessage>;
     private _onClose: Subject<IMessage>;
-    private currentRetryCount = 0;
 
     private static roles() {
         return {
@@ -151,7 +150,7 @@ export class Client {
                 })
                 .do((msg: IMessage) => {
                     if (msg instanceof OpenMessage) {
-                        this.currentRetryCount = 0;
+                        currentRetryCount = 0;
                         const helloMsg = new HelloMessage(r, o);
                         transport.next(helloMsg);
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,7 @@
+import {Promise} from 'es6-shim';
+
+export {WebWorkerTransport} from './Transport/WebWorkerTransport';
+export {WebSocketTransport} from './Transport/WebSocketTransport';
+export {Client} from './Client';
+export {retryWhen} from './Client';
+export * from './Client';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "sourceMap": true,
     "declaration": true,
     "removeComments": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "dist/"
   },
   "typeRoots": [
     "node_modules/@types"


### PR DESCRIPTION
Hi all! Thanks for this library, it works really well.

This pull request changes the following:

- Use and init global currentRetryCount (and remove the unused class variable)
- Use the before unused default Client roles when none are provided

The latest versions of this library changed some things that seem like bugs to me. When the option for retryWhen was added, the currentRetryCount was moved from the Client class to a global variable. However, the initialization still uses the class variable. This leads to an ever increasing duration after multiple reconnects.
